### PR TITLE
Fix a simple docker utility

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,17 +13,13 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /root/.local/bin
 
-RUN git clone https://github.com/eel-brah/kokorodoki kdoki
+COPY . kdoki
 
 WORKDIR /root/.venvs
 RUN python3.12 -m venv kdvenv
 RUN /bin/bash -c "source kdvenv/bin/activate && pip install --upgrade pip && pip install -r /root/.local/bin/kdoki/requirements.txt"
 
-RUN /root/.venvs/kdvenv/bin/python3.12 /root/.local/bin/kdoki/src/main.py --daemon
+RUN /root/.venvs/kdvenv/bin/python3.12 /root/.local/bin/kdoki/src/main.py --setup
 
-COPY ./entrypoint.sh /root/
-RUN chmod +x /root/entrypoint.sh
-
-ENTRYPOINT ["/root/entrypoint.sh"]
+ENTRYPOINT ["/root/.local/bin/kdoki/kokorodoki"]
 CMD []
-

--- a/docker/docker-compose-v1.yml
+++ b/docker/docker-compose-v1.yml
@@ -1,7 +1,7 @@
 x-kdoki-base: &kdoki-base
   build:
-    context: .
-    dockerfile: Dockerfile
+    context: ..
+    dockerfile:  docker/Dockerfile
   runtime: nvidia
   deploy:
     resources:

--- a/docker/docker-compose-v2.yml
+++ b/docker/docker-compose-v2.yml
@@ -1,7 +1,7 @@
 x-kdoki-base: &kdoki-base
   build:
-    context: .
-    dockerfile: Dockerfile
+    context: ..
+    dockerfile: docker/Dockerfile
     runtime: nvidia
     devices:
       - /dev/snd:/dev/snd

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-
-echo "Starting..."
-echo "TTY: $(tty)"
-
-./kdoki/kokorodoki -t " "
-
-exec ./kdoki/kokorodoki "$@"

--- a/src/input_hander.py
+++ b/src/input_hander.py
@@ -34,6 +34,7 @@ class Args:
     input_text: Optional[str]
     output_file: Optional[str]
     all_voices: bool
+    setup: bool
     daemon: bool
     port: int
     gui: bool
@@ -148,6 +149,11 @@ def parse_args() -> Args:
         type=str,
         default=None,
         help="Output file path (only valid when --text or --file is used)",
+    )
+    parser.add_argument(
+        "--setup",
+        action="store_true",
+        help="Download the models and exit (useful for first-time setup)",
     )
     parser.add_argument(
         "--daemon",
@@ -288,6 +294,7 @@ def parse_args() -> Args:
         input_text,
         args.output,
         args.all,
+        args.setup,
         args.daemon,
         args.port,
         args.gui,

--- a/src/models.py
+++ b/src/models.py
@@ -48,7 +48,7 @@ class TTSPlayer:
         self.back = threading.Event()
         self.lock = threading.Lock()
         self.back_number = 0
-        self.audio_player = AudioPlayer(SAMPLE_RATE)
+        self.audio_player = None
         self.ctrlc = not ctrlc
         self.print_complete = True
 
@@ -183,6 +183,8 @@ class TTSPlayer:
     def play_audio(self, gui_highlight=None) -> None:
         """Play audio chunks from the queue."""
         try:
+            if self.audio_player is None:
+                self.audio_player = AudioPlayer(SAMPLE_RATE)
             audio_chunks = []
             audio_size = 0
             self.back_number = 0

--- a/src/run.py
+++ b/src/run.py
@@ -97,7 +97,9 @@ def start(args: Args) -> None:
 
         # audio_warmup()
 
-        if args.daemon:
+        if args.setup:
+            return
+        elif args.daemon:
             easyocr_lang = [
                 lang
                 for code, lang in get_easyocr_language_map().items()


### PR DESCRIPTION
Hello, I am the lead developer of Shotcut video editor (GPLv3). Someone told me about kokorodoki in the forum:
https://forum.shotcut.org/t/tts-text-to-speech-kokorodoki/49240

I have no plans to try to include kokorodoki in our downloads or installs. Rather, I would rather tell people to simply download a docker image. Then, Shotcut can simply invoke the container to run it. I saw the info about docker in your README--nice! I read `docker/DOCKER.md` but that is too complicated. Initially I only want to run it like a simple command line utility without using docker compose. Simply `docker build ...` and `docker run ...`. I don't want desktop integration. I ran into a few problems.

First,`docker run` gave me  "/root/entrypoint.sh: line 7: ./kdoki/kokorodoki: No such file or directory". I looked into `entrypoint.sh` and it seems useless. What does `kokorodoki -t " "` do? Audibly announce itself? Not needed for this basic use case (`-l .. -v .. -t .. -o ..` ).  After fixing that, I kept getting the error "Error querying device -1" because it was trying to open the audio device when it never actually uses it for file output.  

After fixing those, the docker build was now hanging on `RUN ... --daemon` after downloading models. Better to have a special setup mode for that and skip over easyocr and opening a socket. 

Finally, it is not generally desirable to git clone inside the `Dockerfile` especially when you are using the container to test and debug as I am.

I hope this helps.